### PR TITLE
commit changes Address_refactor_SIP-162_0

### DIFF
--- a/si2.bll/Dtos/Requests/Address/CreateAddressDto.cs
+++ b/si2.bll/Dtos/Requests/Address/CreateAddressDto.cs
@@ -28,13 +28,13 @@ namespace si2.bll.Dtos.Requests.Address
         public string CountryAr { get; set; }
 
         [Required]
-        [RegularExpression(@"^-?\d+\.\d{0,7}$", ErrorMessage = "Please enter up to 10 digits for Longitude")]
+        [RegularExpression(@"^-?\d+\.\d{0,7}$", ErrorMessage = "Please enter up to 10 decimal digits for Longitude")]
         [Range(-180, 180)]
         [Column(TypeName = "decimal(10,7)")]
         public decimal Longitude { get; set; }
 
         [Required]
-        [RegularExpression(@"^-?\d+\.\d{0,7}$", ErrorMessage = "Please enter up to 9 digits for Latitude")]
+        [RegularExpression(@"^-?\d+\.\d{0,7}$", ErrorMessage = "Please enter up to 9 decimal digits for Latitude")]
         [Range(-90, 90)]
         [Column(TypeName = "decimal(9,7)")]
         public decimal Latitude { get; set; }

--- a/si2.bll/Dtos/Requests/Address/CreateAddressDto.cs
+++ b/si2.bll/Dtos/Requests/Address/CreateAddressDto.cs
@@ -1,37 +1,42 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Text;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace si2.bll.Dtos.Requests.Address
 {
     public class CreateAddressDto 
     {
         [Required]
-        [MaxLength(100)]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string StreetFr { get; set; }
 
-        [MaxLength(100)]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string StreetAr { get; set; }
 
         [Required]
-        [MaxLength(50)]
+        [StringLength(50, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string CityFr { get; set; }
 
-        [MaxLength(50)]
+        [StringLength(50, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string CityAr { get; set; }
 
         [Required]
-        [MaxLength(50)]
+        [StringLength(50, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string CountryFr { get; set; }
 
-        [MaxLength(50)]
+        [StringLength(50, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string CountryAr { get; set; }
 
         [Required]
+        [RegularExpression(@"^\d+\.\d{0,7}$")]
+        [Range(0, 99.9999999)]
+        [Column(TypeName = "decimal(9,7)")]
         public decimal Longitude { get; set; }
 
         [Required]
+        [RegularExpression(@"^\d+\.\d{0,7}$")]
+        [Range(0, 99.9999999)]
+        [Column(TypeName = "decimal(9,7)")]
         public decimal Latitude { get; set; }
     }
 }

--- a/si2.bll/Dtos/Requests/Address/CreateAddressDto.cs
+++ b/si2.bll/Dtos/Requests/Address/CreateAddressDto.cs
@@ -28,14 +28,14 @@ namespace si2.bll.Dtos.Requests.Address
         public string CountryAr { get; set; }
 
         [Required]
-        [RegularExpression(@"^\d+\.\d{0,7}$")]
-        [Range(0, 99.9999999)]
-        [Column(TypeName = "decimal(9,7)")]
+        [RegularExpression(@"^-?\d+\.\d{0,7}$", ErrorMessage = "Please enter up to 10 digits for Longitude")]
+        [Range(-180, 180)]
+        [Column(TypeName = "decimal(10,7)")]
         public decimal Longitude { get; set; }
 
         [Required]
-        [RegularExpression(@"^\d+\.\d{0,7}$")]
-        [Range(0, 99.9999999)]
+        [RegularExpression(@"^-?\d+\.\d{0,7}$", ErrorMessage = "Please enter up to 9 digits for Latitude")]
+        [Range(-90, 90)]
         [Column(TypeName = "decimal(9,7)")]
         public decimal Latitude { get; set; }
     }

--- a/si2.bll/Dtos/Requests/Address/UpdateAddressDto.cs
+++ b/si2.bll/Dtos/Requests/Address/UpdateAddressDto.cs
@@ -1,37 +1,42 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Text;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace si2.bll.Dtos.Requests.Address
 {
     public class UpdateAddressDto 
     {
         [Required]
-        [MaxLength(100)]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string StreetFr { get; set; }
 
-        [MaxLength(100)]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string StreetAr { get; set; }
 
         [Required]
-        [MaxLength(50)]
+        [StringLength(50, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string CityFr { get; set; }
 
-        [MaxLength(50)]
+        [StringLength(50, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string CityAr { get; set; }
 
         [Required]
-        [MaxLength(50)]
+        [StringLength(50, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string CountryFr { get; set; }
 
-        [MaxLength(50)]
+        [StringLength(50, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string CountryAr { get; set; }
 
         [Required]
+        [RegularExpression(@"^\d+\.\d{0,7}$")]
+        [Range(0, 99.9999999)]
+        [Column(TypeName = "decimal(9,7)")]
         public decimal Longitude { get; set; }
 
         [Required]
+        [RegularExpression(@"^\d+\.\d{0,7}$")]
+        [Range(0, 99.9999999)]
+        [Column(TypeName = "decimal(9,7)")]
         public decimal Latitude { get; set; }
 
         public byte[] RowVersion { get; set; }

--- a/si2.bll/Dtos/Requests/Address/UpdateAddressDto.cs
+++ b/si2.bll/Dtos/Requests/Address/UpdateAddressDto.cs
@@ -28,14 +28,14 @@ namespace si2.bll.Dtos.Requests.Address
         public string CountryAr { get; set; }
 
         [Required]
-        [RegularExpression(@"^\d+\.\d{0,7}$")]
-        [Range(0, 99.9999999)]
-        [Column(TypeName = "decimal(9,7)")]
+        [RegularExpression(@"^-?\d+\.\d{0,7}$", ErrorMessage = "Please enter up to 10 decimal digits for Longitude")]
+        [Range(-180, 180)]
+        [Column(TypeName = "decimal(10,7)")]
         public decimal Longitude { get; set; }
 
         [Required]
-        [RegularExpression(@"^\d+\.\d{0,7}$")]
-        [Range(0, 99.9999999)]
+        [RegularExpression(@"^-?\d+\.\d{0,7}$", ErrorMessage = "Please enter up to 9 decimal digits for Longitude")]
+        [Range(-90, 90)]
         [Column(TypeName = "decimal(9,7)")]
         public decimal Latitude { get; set; }
 

--- a/si2.dal/Entities/Address.cs
+++ b/si2.dal/Entities/Address.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using si2.dal.Interfaces;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -32,11 +31,11 @@ namespace si2.dal.Entities
         public string CountryAr { get; set; }
 
         [Required]
-        [Column(TypeName = "decimal(9,6)")]
+        [Column(TypeName = "decimal(9,7)")]
         public decimal Longitude { get; set; }
 
         [Required]
-        [Column(TypeName = "decimal(8,6)")]
+        [Column(TypeName = "decimal(9,7)")]
         public decimal Latitude { get; set; }
 
         public ICollection<Institution> Institutions { get; set; }

--- a/si2.dal/Entities/Address.cs
+++ b/si2.dal/Entities/Address.cs
@@ -31,7 +31,7 @@ namespace si2.dal.Entities
         public string CountryAr { get; set; }
 
         [Required]
-        [Column(TypeName = "decimal(9,7)")]
+        [Column(TypeName = "decimal(10,7)")]
         public decimal Longitude { get; set; }
 
         [Required]

--- a/si2.dal/Migrations/20200630100301_Address_refactor_migration1.Designer.cs
+++ b/si2.dal/Migrations/20200630100301_Address_refactor_migration1.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using si2.dal.Context;
 
 namespace si2.dal.Migrations
 {
     [DbContext(typeof(Si2DbContext))]
-    partial class Si2DbContextModelSnapshot : ModelSnapshot
+    [Migration("20200630100301_Address_refactor_migration1")]
+    partial class Address_refactor_migration1
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/si2.dal/Migrations/20200630100301_Address_refactor_migration1.cs
+++ b/si2.dal/Migrations/20200630100301_Address_refactor_migration1.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace si2.dal.Migrations
+{
+    public partial class Address_refactor_migration1 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Longitude",
+                table: "Address",
+                type: "decimal(9,7)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(9,6)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Latitude",
+                table: "Address",
+                type: "decimal(9,7)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(8,6)");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Longitude",
+                table: "Address",
+                type: "decimal(9,6)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(9,7)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Latitude",
+                table: "Address",
+                type: "decimal(8,6)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(9,7)");
+        }
+    }
+}

--- a/si2.dal/Migrations/20200701061742_Address_refactor_migration2.Designer.cs
+++ b/si2.dal/Migrations/20200701061742_Address_refactor_migration2.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using si2.dal.Context;
 
 namespace si2.dal.Migrations
 {
     [DbContext(typeof(Si2DbContext))]
-    partial class Si2DbContextModelSnapshot : ModelSnapshot
+    [Migration("20200701061742_Address_refactor_migration2")]
+    partial class Address_refactor_migration2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/si2.dal/Migrations/20200701061742_Address_refactor_migration2.cs
+++ b/si2.dal/Migrations/20200701061742_Address_refactor_migration2.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace si2.dal.Migrations
+{
+    public partial class Address_refactor_migration2 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Longitude",
+                table: "Address",
+                type: "decimal(10,7)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(9,7)");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Longitude",
+                table: "Address",
+                type: "decimal(9,7)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(10,7)");
+        }
+    }
+}


### PR DESCRIPTION
- Added property "[Column(TypeName = "decimal(9,7)")]" for both Latitude and Longitude attributes in Address Entity

- Changed property "MaxLength('x')"  to "[StringLength(x, ErrorMessage = "The \{0} must be at least \{2} and at max \{1} characters long.", MinimumLength = 1)] of attributes in CreateAddressDto and UpdateAddressDto
    
-  Added properties "[RegularExpression(@"^\d+\.\d\\\{0,7}$")] [Range(0, 99.9999999)] [Column(TypeName = "decimal(9,7)")]" for both Latitude and Longitude attributes in CreateAddressDto and UpdateAddressDto