### PR TITLE
commit changes Document_refactor_SIP-163_0

### DIFF
--- a/si2.api/Controllers/DocumentsController.cs
+++ b/si2.api/Controllers/DocumentsController.cs
@@ -11,9 +11,7 @@ using si2.bll.ResourceParameters;
 using si2.bll.Services;
 using si2.dal.Entities;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
@@ -64,6 +62,11 @@ namespace si2.api.Controllers
                 file.ContentType,
                 user.Id,
                 ct);
+
+            if(documentToReturn == null)
+            {
+                return BadRequest();
+            }
 
             return CreatedAtRoute("GetDocument", new { id = documentToReturn.Id }, documentToReturn);
         }

--- a/si2.bll/Dtos/Requests/Document/CreateDocumentDto.cs
+++ b/si2.bll/Dtos/Requests/Document/CreateDocumentDto.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace si2.bll.Dtos.Requests.Document
@@ -12,31 +13,37 @@ namespace si2.bll.Dtos.Requests.Document
         public Guid? ProgramId { get; set; }
 
         [Required]
+        [JsonProperty(Required = Required.Always)]
         [Display(Name = "NameFr")]
         [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string NameFr { get; set; }
 
         [Required]
+        [JsonProperty(Required = Required.Always)]
         [Display(Name = "NameAr")]
         [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string NameAr { get; set; }
 
         [Required]
+        [JsonProperty(Required = Required.Always)]
         [Display(Name = "NameEn")]
         [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string NameEn { get; set; }
 
         [Required]
+        [JsonProperty(Required = Required.Always)]
         [Display(Name = "DescriptionFr")]
         [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string DescriptionFr { get; set; }
 
         [Required]
+        [JsonProperty(Required = Required.Always)]
         [Display(Name = "DescriptionAr")]
         [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string DescriptionAr { get; set; }
 
         [Required]
+        [JsonProperty(Required = Required.Always)]
         [Display(Name = "DescriptionEn")]
         [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
         public string DescriptionEn { get; set; }

--- a/si2.bll/Services/DocumentService.cs
+++ b/si2.bll/Services/DocumentService.cs
@@ -27,6 +27,22 @@ namespace si2.bll.Services
 
             try
             {
+
+                if (createDocumentDto.InstitutionId != null)
+                {
+                    if (await _uow.Institutions.GetAsync(createDocumentDto.InstitutionId, ct) == null)
+
+                        return null;
+                }
+
+                if (createDocumentDto.ProgramId != null)
+                {
+                    if (await _uow.Programs.GetAsync(createDocumentDto.ProgramId, ct) == null)
+
+                        return null;
+                }
+
+
                 documentEntity = _mapper.Map<Document>(createDocumentDto);
 
                 documentEntity.OriginalFileName = fileName;
@@ -50,6 +66,7 @@ namespace si2.bll.Services
             return documentDto;
         }
 
+        
 
         public async Task<DocumentDto> GetDocumentByIdAsync(Guid id, CancellationToken ct)
         {

--- a/si2.dal/Repositories/IRepository.cs
+++ b/si2.dal/Repositories/IRepository.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -29,6 +28,7 @@ namespace si2.dal.Repositories
         Task<ICollection<TEntity>> GetAllAsync(CancellationToken ct);
         IQueryable<TEntity> GetAllIncluding(params Expression<Func<TEntity, object>>[] includeProperties);
         Task<TEntity> GetAsync(Guid id, CancellationToken ct);
+        Task<TEntity> GetAsync(Guid? id, CancellationToken ct);
         void Save();
         Task<int> SaveAsync(CancellationToken ct);
         TEntity Update(TEntity t, object key, byte[] rowVersion = null);

--- a/si2.dal/Repositories/Repository.cs
+++ b/si2.dal/Repositories/Repository.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -45,6 +44,11 @@ namespace si2.dal.Repositories
         }
 
         public virtual async Task<TEntity> GetAsync(Guid id, CancellationToken ct)
+        {
+            return await _db.Set<TEntity>().FindAsync(new object[] { id }, ct);
+        }
+
+        public virtual async Task<TEntity> GetAsync(Guid? id, CancellationToken ct)
         {
             return await _db.Set<TEntity>().FindAsync(new object[] { id }, ct);
         }


### PR DESCRIPTION
- String fileInfoText is used to sent the metadata

- Need to convert the string into an object, the model, in this case the CreateDocumentDto

- We use JsonConvert.DeserializeObject<Model>(string)

- The Json Deserialize have it's own attributes and in this case "[JsonProperty(Required = Required.Always)]" property, which was added for required attributes in the CreateDocumentDto

- Changed the "UploadDocumentAsync" method in the DocumentService class, in order to check on the "InstitutionId" and the "ProgramId" if they exist while uploading a document

- For that had to create a method GetAsync with Guid? as nullable since both foreign keys can be null, in IRepository class and implemented it in Repository class