### PR TITLE
Feature/sip 173

### DIFF
--- a/si2.dal/Context/Si2DbContext.cs
+++ b/si2.dal/Context/Si2DbContext.cs
@@ -56,10 +56,9 @@ namespace si2.dal.Context
 
             base.OnModelCreating(builder);
 
-			builder.Entity<ProgramLevel>().HasIndex(pl => pl.NameFr).IsUnique().HasName("IX_ProgramLevel_NameFr"); ;
-			builder.Entity<ProgramLevel>().HasIndex(pl => pl.NameEn).IsUnique().HasName("IX_ProgramLevel_NameEn"); ;
-			builder.Entity<ProgramLevel>().HasIndex(pl => pl.NameAr).IsUnique().HasName("IX_ProgramLevel_NameAr"); ;
-            //builder.Entity<Cohort>().HasIndex(c => c.Promotion).IsUnique();
+			builder.Entity<ProgramLevel>().HasIndex(pl => pl.NameFr).IsUnique().HasName("IX_ProgramLevel_NameFr");
+			builder.Entity<ProgramLevel>().HasIndex(pl => pl.NameEn).IsUnique().HasName("IX_ProgramLevel_NameEn");
+			builder.Entity<ProgramLevel>().HasIndex(pl => pl.NameAr).IsUnique().HasName("IX_ProgramLevel_NameAr");
             builder.Entity<Cohort>().HasIndex(c => new { c.Promotion, c.ProgramId }).IsUnique();
             builder.Entity<UserCohort>().HasIndex(uc => new { uc.UserId, uc.CohortId }).IsUnique();
             builder.Entity<Program>().HasIndex(p => p.Code).IsUnique();

--- a/si2.dal/Context/Si2DbContext.cs
+++ b/si2.dal/Context/Si2DbContext.cs
@@ -59,7 +59,8 @@ namespace si2.dal.Context
 			builder.Entity<ProgramLevel>().HasIndex(pl => pl.NameFr).IsUnique().HasName("IX_ProgramLevel_NameFr"); ;
 			builder.Entity<ProgramLevel>().HasIndex(pl => pl.NameEn).IsUnique().HasName("IX_ProgramLevel_NameEn"); ;
 			builder.Entity<ProgramLevel>().HasIndex(pl => pl.NameAr).IsUnique().HasName("IX_ProgramLevel_NameAr"); ;
-            builder.Entity<Cohort>().HasIndex(c => c.Promotion).IsUnique();
+            //builder.Entity<Cohort>().HasIndex(c => c.Promotion).IsUnique();
+            builder.Entity<Cohort>().HasIndex(c => new { c.Promotion, c.ProgramId }).IsUnique();
             builder.Entity<UserCohort>().HasIndex(uc => new { uc.UserId, uc.CohortId }).IsUnique();
             builder.Entity<Program>().HasIndex(p => p.Code).IsUnique();
             builder.Entity<Institution>().HasIndex(i => i.Code).IsUnique().HasName("IX_Institution_Code");

--- a/si2.dal/Migrations/20200703080200_Cohort_refactor_migration1.Designer.cs
+++ b/si2.dal/Migrations/20200703080200_Cohort_refactor_migration1.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using si2.dal.Context;
 
 namespace si2.dal.Migrations
 {
     [DbContext(typeof(Si2DbContext))]
-    partial class Si2DbContextModelSnapshot : ModelSnapshot
+    [Migration("20200703080200_Cohort_refactor_migration1")]
+    partial class Cohort_refactor_migration1
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/si2.dal/Migrations/20200703080200_Cohort_refactor_migration1.cs
+++ b/si2.dal/Migrations/20200703080200_Cohort_refactor_migration1.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace si2.dal.Migrations
+{
+    public partial class Cohort_refactor_migration1 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Cohort_Promotion",
+                table: "Cohort");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Cohort_Promotion_ProgramId",
+                table: "Cohort",
+                columns: new[] { "Promotion", "ProgramId" },
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Cohort_Promotion_ProgramId",
+                table: "Cohort");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Cohort_Promotion",
+                table: "Cohort",
+                column: "Promotion",
+                unique: true);
+        }
+    }
+}


### PR DESCRIPTION
- Changed unique rule on Cohort object when calling Post request of Cohort (Si2DbContext.cs file)

- Creating a new Cohort will now require a check on duplication key value "IX_Cohort_Promotion_ProgramId"

- Created migration and updated database to apply changes